### PR TITLE
Fix compilation on RHEL6

### DIFF
--- a/src/logging/level.cpp
+++ b/src/logging/level.cpp
@@ -1,3 +1,4 @@
+#include "common.h"
 #include <stdexcept>
 #include <iostream>
 
@@ -62,7 +63,7 @@ Level Level::fromValue(const uint32_t value)
   if (it != valueMap.end()) {
     return it->second;
   } else {
-    throw range_error("No such level with value " + std::to_string(value));
+    throw range_error("No such level with value " + to_string((llui_t)value));
   }
 }
 


### PR DESCRIPTION
This fixes the following compile error on Red Hat Enterprise Linux 6 : 
```
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I../build-aux -D_GNU_SOURCE -Wall -pedantic-errors -O2 -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -std=c++0x -MT net/device.lo -MD -MP -MF net/.deps/device.Tpo -c net/device.cpp  -fPIC -DPIC -o net/.libs/device.o
logging/level.cpp: In static member function 'static mckeys::Level mckeys::Level::fromValue(uint32_t)':
logging/level.cpp:65: error: call of overloaded 'to_string(const uint32_t&)' is ambiguous
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/basic_string.h:2604: note: candidates are: std::string std::to_string(long long int)
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/basic_string.h:2610: note:                 std::string std::to_string(long long unsigned int)
/usr/lib/gcc/x86_64-redhat-linux/4.4.7/../../../../include/c++/4.4.7/bits/basic_string.h:2616: note:                 std::string std::to_string(long double)
make[1]: *** [logging/level.lo] Error 1
```
I looked at the other calls to `to_string()` and saw that variables were being cast with types declared in `common.h`, so I just did the same.